### PR TITLE
Fixed wrong height on compact size classes

### DIFF
--- a/Sources/DatePickerDialog.swift
+++ b/Sources/DatePickerDialog.swift
@@ -176,6 +176,7 @@ public class DatePickerDialog: UIView {
         self.datePicker = UIDatePicker(frame: CGRect(x: 0, y: 30, width: 0, height: 0))
         self.datePicker.autoresizingMask = .flexibleRightMargin
         self.datePicker.frame.size.width = 300
+        self.datePicker.frame.size.height = 216
         dialogContainer.addSubview(self.datePicker)
 
         // Add the buttons


### PR DESCRIPTION
**Forces the height of the date picker to 216 points to prevent smaller height on compact height size classes.**

Whenever the dialog is shown while in a compact height size class (for example in landscape mode on smaller phones) the DatePicker invokes its default behaviour of autoresizing its height to 162 points on initialisation. Since the dialog is build with the expectation of a 216 point DatePicker this smaller DatePicker looks out place.

The fix for this is to explicitly set the DatePicker height to 216.