### PR TITLE
Use Double.pi over M_PI

### DIFF
--- a/Sources/DatePickerDialog.swift
+++ b/Sources/DatePickerDialog.swift
@@ -108,7 +108,7 @@ open class DatePickerDialog: UIView {
         let currentTransform = self.dialogView.layer.transform
         
         let startRotation = (self.value(forKeyPath: "layer.transform.rotation.z") as? NSNumber) as? Double ?? 0.0
-        let rotation = CATransform3DMakeRotation((CGFloat)(-startRotation + M_PI * 270 / 180), 0, 0, 0)
+        let rotation = CATransform3DMakeRotation((CGFloat)(-startRotation + Double.pi * 270 / 180), 0, 0, 0)
         
         self.dialogView.layer.transform = CATransform3DConcat(rotation, CATransform3DMakeScale(1, 1, 1))
         self.dialogView.layer.opacity = 1


### PR DESCRIPTION
Swift 3 integrates the pi constant in the Float, Double and CGFloat types, so we should prefer those. Minor compiler warning. Very simple to fix!