### PR TITLE
Default date & background tap

### DIFF
--- a/Sources/DatePickerDialog.swift
+++ b/Sources/DatePickerDialog.swift
@@ -97,9 +97,12 @@ open class DatePickerDialog: UIView {
         self.callback = callback
         self.defaultDate = defaultDate
         self.datePicker.datePickerMode = self.datePickerMode ?? UIDatePickerMode.date
-        self.datePicker.date = self.defaultDate ?? Date()
         self.datePicker.maximumDate = maximumDate
         self.datePicker.minimumDate = minimumDate
+        
+        // This needs to be set after the `minimumDate` or you end up with the minimumDate displayed. You *could* do this in the calling/client code (i.e., self.datePicker is public), but you may get scrolling while the picker is displayed. Which is less than good UX.
+        self.datePicker.date = self.defaultDate ?? Date()
+
         if let locale = self.locale {
             self.datePicker.locale = locale
         }


### PR DESCRIPTION
I fixed an issue where the default date wasn't displayed. I also provided an option where you can tap on the background to dismiss the picker (this is turned off by default).

Future plan: I have a need to customize the font throughout the picker so will likely do that next and make another PR.