### PR TITLE
Added support for iOS 13 Dark Mode

### DIFF
--- a/Sources/DatePickerDialog.swift
+++ b/Sources/DatePickerDialog.swift
@@ -31,11 +31,12 @@ open class DatePickerDialog: UIView {
 
     private var textColor: UIColor!
     private var buttonColor: UIColor!
+    private var viewBorderColor: UIColor!
     private var font: UIFont!
 
     // MARK: - Dialog initialization
-    @objc public init(textColor: UIColor = UIColor.black,
-                buttonColor: UIColor = UIColor.blue,
+    @objc public init(textColor: UIColor = getDefaultTextColor(),
+                buttonColor: UIColor = getDefaultButtonColor(),
                 font: UIFont = .boldSystemFont(ofSize: 15),
                 locale: Locale? = nil,
                 showCancelButton: Bool = true) {
@@ -43,6 +44,12 @@ open class DatePickerDialog: UIView {
         super.init(frame: CGRect(x: 0, y: 0, width: size.width, height: size.height))
         self.textColor = textColor
         self.buttonColor = buttonColor
+        if #available(iOS 13.0, *){
+            self.viewBorderColor =  UIColor.systemGray3
+        }
+        else{
+            self.viewBorderColor =  UIColor(red: 198/255, green: 198/255, blue: 198/255, alpha: 1)
+        }
         self.font = font
         self.showCancelButton = showCancelButton
         self.locale = locale
@@ -51,6 +58,24 @@ open class DatePickerDialog: UIView {
 
     @objc required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+    }
+    
+    public class func getDefaultTextColor() -> UIColor {
+        if #available(iOS 13.0, *){
+            return UIColor.label
+        }
+        else{
+            return UIColor.black
+        }
+    }
+    
+    public class func getDefaultButtonColor() -> UIColor {
+        if #available(iOS 13.0, *){
+            return UIColor.systemBlue
+        }
+        else{
+            return UIColor.blue
+        }
     }
 
     func setupView() {
@@ -181,18 +206,27 @@ open class DatePickerDialog: UIView {
         // First, we style the dialog to match the iOS8 UIAlertView >>>
         let gradient: CAGradientLayer = CAGradientLayer(layer: self.layer)
         gradient.frame = container.bounds
-        gradient.colors = [
-            UIColor(red: 218/255, green: 218/255, blue: 218/255, alpha: 1).cgColor,
-            UIColor(red: 233/255, green: 233/255, blue: 233/255, alpha: 1).cgColor,
-            UIColor(red: 218/255, green: 218/255, blue: 218/255, alpha: 1).cgColor
-        ]
+        if #available(iOS 13, *){
+            gradient.colors = [
+                UIColor.secondarySystemBackground.cgColor,
+                UIColor.systemBackground.cgColor,
+                UIColor.secondarySystemBackground.cgColor
+            ]
+        }
+        else{
+            gradient.colors = [
+                UIColor(red: 218/255, green: 218/255, blue: 218/255, alpha: 1).cgColor,
+                UIColor(red: 233/255, green: 233/255, blue: 233/255, alpha: 1).cgColor,
+                UIColor(red: 218/255, green: 218/255, blue: 218/255, alpha: 1).cgColor
+            ]
+        }
 
         let cornerRadius = kCornerRadius
         gradient.cornerRadius = cornerRadius
         container.layer.insertSublayer(gradient, at: 0)
 
         container.layer.cornerRadius = cornerRadius
-        container.layer.borderColor = UIColor(red: 198/255, green: 198/255, blue: 198/255, alpha: 1).cgColor
+        container.layer.borderColor = viewBorderColor.cgColor
         container.layer.borderWidth = 1
         container.layer.shadowRadius = cornerRadius + 5
         container.layer.shadowOpacity = 0.1
@@ -212,7 +246,7 @@ open class DatePickerDialog: UIView {
             height: kDefaultButtonSpacerHeight
         ))
 
-        lineView.backgroundColor = UIColor(red: 198/255, green: 198/255, blue: 198/255, alpha: 1)
+        lineView.backgroundColor = viewBorderColor
         container.addSubview(lineView)
 
         //Title


### PR DESCRIPTION
This PR is to add support for the new iOS 13 Dark mode.

Changes made:

- Changed color references to dynamic iOS 13 colors (with #available check for iOS 12 and earlier support)

- Default color assignment in initializer moved to functions so availability check can be applied